### PR TITLE
Updated to use security group ids as required by installation of boto3.

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -6,7 +6,7 @@ class Config:
     ec2_region = ""
     ec2_amis = ['']
     ec2_keypair = ''
-    ec2_secgroups = ['']
+    ec2_secgroups = [''] #ID Not Name
     ec2_instancetype = ''
 
     #SSH Key Path

--- a/readme.md
+++ b/readme.md
@@ -110,3 +110,9 @@ The title and header for the site can be changed in **/templates/index.html**. F
 
 ## Server Maintenance
 Maintaining the server is fairly straightforward and is done primarily through FileZilla. Updating the server file can be done by downloading the new server file, renaming it to **server.jar** and replacing the old file on the server. The world file can be backed up to your PC manually though there is no automated process at this time.
+
+## Troouble Shooting Issues
+Issues with boto3, try running:
+```
+python -m pip install --user boto3
+```

--- a/utilityScripts/createInstance.py
+++ b/utilityScripts/createInstance.py
@@ -11,11 +11,11 @@ client = boto3.resource(
             region_name=Config.ec2_region
         )
 response = client.create_instances(ImageId = Config.ec2_amis[0],
-    InstanceType = Config.ec2_instancetype, 
+    InstanceType = Config.ec2_instancetype,
     KeyName = Config.ec2_keypair,
     MaxCount = 1,
     MinCount = 1,
-    SecurityGroups = Config.ec2_secgroups)
+    SecurityGroupIds = Config.ec2_secgroups)
 
 print("INSTANCE CREATED")
 print("INSTANCE ID: " + response[0].id)


### PR DESCRIPTION
Unsure why my installation required them to be the group id's. Do group names work for anyone else?