### PR TITLE
Store configuration variables in Heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .DS_STORE
 *.pem
 /.vs/slnx.sqlite
+.env
+env/

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web gunicorn server:app
+web: gunicorn server:app

--- a/configuration.py
+++ b/configuration.py
@@ -1,17 +1,7 @@
 class Config:
-    #AWS Information
-    ACCESS_KEY = ''
-    SECRET_KEY = ''
-    INSTANCE_ID = ''
-    ec2_region = ""
+    # AWS Information
+    ec2_region = ""  # Same as environment variable EC2_REGION
     ec2_amis = ['']
     ec2_keypair = ''
     ec2_secgroups = ['']
     ec2_instancetype = ''
-
-    #SSH Key Path
-    SSH_KEY_FILE_PATH = ''
-
-    #Server Memory Size
-    #This is default to no memory specification but can be: '-Xmx1024M -Xms1024M ' (KEEP TRAILING SPACE)
-    MEMORY_ALLOCATION='' 

--- a/server.py
+++ b/server.py
@@ -17,11 +17,8 @@ key = paramiko.RSAKey.from_private_key(io.StringIO(key_string))
 sshClient = paramiko.SSHClient()
 sshClient.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-# Waits for the server to reach a valid state so that commands can be executed on the server
-
-
 def serverWaitOk(instanceIp, client):
-
+    """Waits for the server to reach a valid state so that commands can be executed on the server"""
     checksPassed = False
     status = 'initializing'
     instanceIds = [os.getenv('INSTANCE_ID')]
@@ -41,10 +38,9 @@ def serverWaitOk(instanceIp, client):
     else:
         print('An error has occurred booting the server')
 
-# SSH connects to server and executes command to boot minecraft server
-
 
 def initServerCommands(instanceIp):
+    """SSH connects to server and executes command to boot minecraft server"""
     # Connect/ssh to an instance
     try:
         # Here 'ubuntu' is user name and 'instance_ip' is public IP of EC2
@@ -61,11 +57,10 @@ def initServerCommands(instanceIp):
         print('Error running server commands')
         print(err)
 
-# Main endpoint for loading the webpage
-
 
 @app.route('/')
 def loadIndex():
+    """Main endpoint for loading the webpage"""
     return render_template('index.html')
 
 
@@ -90,8 +85,8 @@ def initServerMC():
     return render_template('index.html', ipMessage=message)
 
 
-# Gets IP Address for return to webpage otherwise boots server
 def manageServer(client):
+    """Gets IP Address for return to webpage otherwise boots server"""
     returnString = 'ERROR'
 
     instanceIds = [os.getenv('INSTANCE_ID')]
@@ -118,10 +113,8 @@ def manageServer(client):
             returnString = 'ERROR'
     return returnString
 
-# Starts the specified AWS Instance from the configuration
-
-
 def startServer(client):
+    """Starts the specified AWS Instance from the configuration"""
     # Gets proper variables to attempt to instantiate EC2 instance and start minecraft server
     returnString = 'ERROR'
     instanceIds = [os.getenv('INSTANCE_ID')]

--- a/utilityScripts/createInstance.py
+++ b/utilityScripts/createInstance.py
@@ -4,10 +4,17 @@ import boto3
 sys.path.append(os.path.dirname(os.path.abspath("configuration.py")))
 from configuration import Config
 
+if not len(sys.argv) == 3:
+    print("Usage: createInstance.py <AWS access key> <AWS secret key>")
+    sys.exit()
+
+ACCESS_KEY = sys.argv[1]
+SECRET_KEY = sys.argv[2]
+
 client = boto3.resource(
             'ec2',
-            aws_access_key_id=Config.ACCESS_KEY,
-            aws_secret_access_key=Config.SECRET_KEY,
+            aws_access_key_id=ACCESS_KEY,
+            aws_secret_access_key=SECRET_KEY,
             region_name=Config.ec2_region
         )
 response = client.create_instances(ImageId = Config.ec2_amis[0],


### PR DESCRIPTION
Do the configuration variable part of issue #20 

Avoid security issues by storing all app configuration in Heroku configuration variables. Readme is updated to reflect the new way of doing it. The `createInstance.py` script also accepts the AWS key and secret as command line args.

You can test this out locally by adding each variable as a `KEY=VALUE` entry in a `.env` file and running `heroku local` (there's a minor fix in the Procfile to allow this).